### PR TITLE
Forced cblas to link on x64 Linux

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -44,6 +44,7 @@
             "<!(pwd)/include"
         ],
         'libraries': [
+            '-Wl,--no-as-needed',
             '-lcblas'
         ],
         'xcode_settings': {


### PR DESCRIPTION
This should fix #54. I've only tested locally, but adding `-Wl,--no-as-needed` to the `libraries` section of `binding.gyp` forced g++ to tell the linker to compile with libraries, even if no symbol from those libraries are used. Really, we should find out why the linker assumes we're not using any symbols from cblas (Is it because all the code that relies on cblas is in the precompiled snowboy blob?)