### PR TITLE
Using -Wl,--no-as-needed for ARM

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -24,6 +24,9 @@
             }],
             ['OS=="linux" and target_arch=="arm"', {
                 'link_settings': {
+                    'ldflags': [
+                        '-Wl,--no-as-needed',
+                    ],
                     'libraries': [
                         '<(module_root_dir)/lib/rpi/libsnowboy-detect.a',
                     ]


### PR DESCRIPTION
I believe #54 & #61 also effects ARM devices (Pi). I was testing with a fresh Jessie install and was getting the following when running snowboy:

```
module.js:597
  return process.dlopen(module, path._makeLong(filename));
                 ^

Error: libcblas.so.3: cannot open shared object file: No such file or directory
    at Error (native)
    at Object.Module._extensions..node (module.js:597:18)
    at Module.load (module.js:487:32)
    at tryModuleLoad (module.js:446:12)
    at Function.Module._load (module.js:438:3)
    at Module.require (module.js:497:17)
    at require (internal/module.js:20:19)
    at Object.<anonymous> (/home/pi/smart-mirror/node_modules/snowboy/lib/node/index.js:7:29)
    at Module._compile (module.js:570:32)
    at Object.Module._extensions..js (module.js:579:10)
```

Installing `libatlas-base-dev` fixed the issue, but I think adding the `-Wl,--no-as-needed` flag for the Pi should eliminate this as a requirement.

I haven't had the chance to test this, but I thought I'd create a PR so the issue could be tracked.