### PR TITLE
Build node 7.x prebuilt binary

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,6 +35,7 @@ env:
     - NODE_VERSION="4.0.0"
     - NODE_VERSION="5.0.0"
     - NODE_VERSION="6.0.0"
+    - NODE_VERSION="7.0.0"
 
 before_install:
 # use the correct version of node


### PR DESCRIPTION
After merging, this should fix #117. I have verified building the binaries works in Node 7.
I've also updated my auto-publish script for the pi: [`node-pre-gyp_publish.sh`](https://gist.github.com/evancohen/7744c18b7d93b7f5a1b1f64ceb99df20).

Should also fix evancohen/sonus#29

If you rebase this commit, the binaries should be programmatically republished.  
Hooray for 1-line PRs! 🚀 