### PR TITLE
Add Go support

### DIFF
--- a/examples/Go/main.go
+++ b/examples/Go/main.go
@@ -1,0 +1,39 @@
+package main
+
+import (
+	"fmt"
+	"io/ioutil"
+	"unsafe"
+	"os"
+
+	"github.com/Kitt-AI/snowboy/swig/Go"
+)
+
+func main() {
+	if len(os.Args) < 3 {
+		fmt.Printf("usage: %s <keyword.umdl> <wav file>\n", os.Args[0])
+		return
+	}
+	fmt.Printf("Snowboy detecting keyword in %s\n", os.Args[2])
+	detector := snowboydetect.NewSnowboyDetect("../../resources/common.res", os.Args[1])
+	detector.SetSensitivity("0.5")
+	detector.SetAudioGain(1)
+	defer snowboydetect.DeleteSnowboyDetect(detector)
+
+	dat, err := ioutil.ReadFile(os.Args[2])
+	if err != nil {
+		panic(err)
+	}
+
+	ptr := snowboydetect.SwigcptrInt16_t(unsafe.Pointer(&dat[0]))
+	res := detector.RunDetection(ptr, len(dat) / 2 /* len of int16  */)
+	if res == -2 {
+		fmt.Println("Snowboy detected silence")
+	} else if res == -1 {
+		fmt.Println("Snowboy detection returned error")
+	} else if res == 0 {
+		fmt.Println("Snowboy detected nothing")
+	} else {
+		fmt.Println("Snowboy detected keyword ", res)
+	}
+}

--- a/examples/Go/readme.md
+++ b/examples/Go/readme.md
@@ -1,0 +1,40 @@
+## Dependencies
+
+### Swig
+http://www.swig.org/
+
+### Go Package
+```
+go get github.com/Kitt-AI/snowboy/swig/Go
+```
+
+## Building
+
+```
+go build -o snowboy main.go
+```
+
+## Running
+
+```
+./snowboy <keyword.umdl> <wav file>
+```
+
+### Examples
+Cmd:
+`./snowboy ../../resources/snowboy.umdl ../../resources/snowboy.wav`
+
+Output:
+```
+Snowboy detecting keyword in ../../resources/snowboy.wav
+Snowboy detected keyword  1
+```
+
+Cmd:
+`./snowboy ../../resources/alexa.umdl ../../resources/snowboy.wav`
+
+Output:
+```
+Snowboy detecting keyword in ../../resources/snowboy.wav
+Snowboy detected nothing
+```

--- a/swig/Go/snowboy.go
+++ b/swig/Go/snowboy.go
@@ -1,0 +1,9 @@
+package snowboydetect
+
+/*
+#cgo CXXFLAGS: -std=c++11
+#cgo linux,amd64 LDFLAGS: -lcblas -L${SRCDIR}/../../lib/ubuntu64 -lsnowboy-detect
+#cgo linux,arm   LDFLAGS: -lcblas -L${SRCDIR}/../../lib/rpi -lsnowboy-detect
+#cgo darwin      LDFLAGS: -lcblas -L${SRCDIR}/../../lib/osx -lsnowboy-detect
+ */
+import "C"

--- a/swig/Go/snowboydetect.swigcxx
+++ b/swig/Go/snowboydetect.swigcxx
@@ -1,0 +1,13 @@
+// swig/Go/snowboydetect.swigcxx
+
+%module snowboydetect
+
+// Suppress SWIG warnings.
+#pragma SWIG nowarn=SWIGWARN_PARSE_NESTED_CLASS
+%include "std_string.i"
+
+%{
+#include "../../include/snowboy-detect.h"
+%}
+
+%include "../../include/snowboy-detect.h"


### PR DESCRIPTION
- Added Go SWIG wrapper (Go style with snowboydetect.swigcxx) so `go build` sees it and automatically builds
- Added example code (under examples/Go) to help get started.
- Fixes #122 (Golang Bindings)