### PR TITLE
fix link order in go bindings for gcc/g++

### DIFF
--- a/swig/Go/snowboy.go
+++ b/swig/Go/snowboy.go
@@ -2,8 +2,8 @@ package snowboydetect
 
 /*
 #cgo CXXFLAGS: -std=c++11 -D_GLIBCXX_USE_CXX11_ABI=0 
-#cgo linux,amd64 LDFLAGS: -lcblas -L${SRCDIR}/../../lib/ubuntu64 -lsnowboy-detect
-#cgo linux,arm   LDFLAGS: -lcblas -L${SRCDIR}/../../lib/rpi -lsnowboy-detect
-#cgo darwin      LDFLAGS: -lcblas -L${SRCDIR}/../../lib/osx -lsnowboy-detect
+#cgo linux,amd64 LDFLAGS: -L${SRCDIR}/../../lib/ubuntu64 -lsnowboy-detect -lcblas
+#cgo linux,arm   LDFLAGS: -L${SRCDIR}/../../lib/rpi -lsnowboy-detect -lcblas
+#cgo darwin      LDFLAGS: -L${SRCDIR}/../../lib/osx -lsnowboy-detect -lcblas
  */
 import "C"


### PR DESCRIPTION
`-lcblas` must come after `-lsnowboy-detect` so the cblas symbols can be linked properly. Previously worked with with clang but not for gcc/g++.

Before this fix, when building with gcc on Ubuntu, compilation failed with

```
#` github.com/Kitt-AI/snowboy/swig/Go
../../Kitt-AI/snowboy/swig/Go/../../lib/ubuntu64/libsnowboy-detect.a(matrix-wrapper.o): In function `snowboy::MatrixBase::Scale(float)':
matrix-wrapper.cc:(.text+0xda6): undefined reference to `cblas_sscal'
../../Kitt-AI/snowboy/swig/Go/../../lib/ubuntu64/libsnowboy-detect.a(matrix-wrapper.o): In function `snowboy::MatrixBase::AddMat(float, snowboy::MatrixBase const&, snowboy::MatrixTransposeType)':
matrix-wrapper.cc:(.text+0xe73): undefined reference to `cblas_saxpy'
matrix-wrapper.cc:(.text+0xed0): undefined reference to `cblas_saxpy'
../../Kitt-AI/snowboy/swig/Go/../../lib/ubuntu64/libsnowboy-detect.a(matrix-wrapper.o): In function `snowboy::MatrixBase::AddMatMat(float, snowboy::MatrixBase const&, snowboy::MatrixTransposeType, snowboy::MatrixBase const&, snowboy::MatrixTransposeType, float)':
matrix-wrapper.cc:(.text+0x10b6): undefined reference to `cblas_sgemm'
../../Kitt-AI/snowboy/swig/Go/../../lib/ubuntu64/libsnowboy-detect.a(matrix-wrapper.o): In function `snowboy::MatrixBase::AddVecVec(float, snowboy::VectorBase const&, snowboy::VectorBase const&)':
matrix-wrapper.cc:(.text+0x1103): undefined reference to `cblas_sger'
../../Kitt-AI/snowboy/swig/Go/../../lib/ubuntu64/libsnowboy-detect.a(matrix-wrapper.o): In function `snowboy::MatrixBase::Scale(float)':
matrix-wrapper.cc:(.text+0xdee): undefined reference to `cblas_sscal'
../../Kitt-AI/snowboy/swig/Go/../../lib/ubuntu64/libsnowboy-detect.a(vector-wrapper.o): In function `snowboy::VectorBase::AddDiagMat2(float, snowboy::MatrixBase const&, snowboy::MatrixTransposeType, float)':
vector-wrapper.cc:(.text+0x73d): undefined reference to `cblas_sdot'
vector-wrapper.cc:(.text+0x7c1): undefined reference to `cblas_sdot'
../../Kitt-AI/snowboy/swig/Go/../../lib/ubuntu64/libsnowboy-detect.a(vector-wrapper.o): In function `snowboy::VectorBase::AddMatVec(float, snowboy::MatrixBase const&, snowboy::MatrixTransposeType, snowboy::VectorBase const&, float)':
vector-wrapper.cc:(.text+0xfae): undefined reference to `cblas_sgemv'
../../Kitt-AI/snowboy/swig/Go/../../lib/ubuntu64/libsnowboy-detect.a(vector-wrapper.o): In function `snowboy::VectorBase::Norm(float) const':
vector-wrapper.cc:(.text+0x18ea): undefined reference to `cblas_snrm2'
../../Kitt-AI/snowboy/swig/Go/../../lib/ubuntu64/libsnowboy-detect.a(vector-wrapper.o): In function `snowboy::VectorBase::AddVec(float, snowboy::VectorBase const&)':
vector-wrapper.cc:(.text+0x436): undefined reference to `cblas_saxpy'
../../Kitt-AI/snowboy/swig/Go/../../lib/ubuntu64/libsnowboy-detect.a(vector-wrapper.o): In function `snowboy::VectorBase::Scale(float)':
vector-wrapper.cc:(.text+0x7fc): undefined reference to `cblas_sscal'
../../Kitt-AI/snowboy/swig/Go/../../lib/ubuntu64/libsnowboy-detect.a(vector-wrapper.o): In function `snowboy::VectorBase::DotVec(snowboy::VectorBase const&) const':
vector-wrapper.cc:(.text+0x926): undefined reference to `cblas_sdot'
collect2: error: ld returned 1 exit status
```


With fix, tested with clang, gcc/g++ 4.9.4, and gcc/g++ 5.4.1 and everything compiles as expected.