### PR TITLE
Fix problems with pip distribution model and inclusion of resources

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,4 +1,3 @@
-recursive-include examples/Python *
 recursive-include include *
 recursive-include lib *
 recursive-include swig/Python *
@@ -7,3 +6,7 @@ include README.md
 
 exclude *.txt
 exclude *.pyc
+global-exclude .DS_Store _snowboydetect.so
+prune resources/alexa
+prune lib/ios
+prune lib/android


### PR DESCRIPTION
I've found some problems on the implementation of #190 when it was used with `pip`. Mainly, the issue is that `pip`'s distribution is different than plain `setup install` and was not installing the `resources` folder on the same place as the python code, therefore causing a segmentation fault (missing `common.res`).

It is now fixed! You can test it out with:

```
pip install snowboy
```

I also recommend that the maintainers take the time to create an account on [pypi](https://pypi.python.org) and [testpypi](https://testpypi.python.org) and send the username so that I can add it as the package's owner 😃 . 