### PR TITLE
Wrapper around HotwordDetector class to allow for multithreading with detectors

### DIFF
--- a/examples/Python/demo4.py
+++ b/examples/Python/demo4.py
@@ -13,7 +13,7 @@ def signal_handler(signal, frame):
 
 if len(sys.argv) == 1:
     print("Error: need to specify model name")
-    print("Usage: python demo.py your.model")
+    print("Usage: python demo4.py your.model")
     sys.exit(-1)
 
 model = sys.argv[1]

--- a/examples/Python/demo4.py
+++ b/examples/Python/demo4.py
@@ -1,0 +1,45 @@
+import snowboythreaded
+import sys
+import signal
+import time
+
+stop_program = False
+
+
+def signal_handler(signal, frame):
+    global stop_program
+    stop_program = True
+
+
+if len(sys.argv) == 1:
+    print("Error: need to specify model name")
+    print("Usage: python demo.py your.model")
+    sys.exit(-1)
+
+model = sys.argv[1]
+
+# capture SIGINT signal, e.g., Ctrl+C
+signal.signal(signal.SIGINT, signal_handler)
+
+# Initialize ThreadedDetector object and start the detection thread
+threaded_detector = snowboythreaded.ThreadedDetector(model, sensitivity=0.5)
+threaded_detector.start()
+
+print('Listening... Press Ctrl+C to exit')
+
+# main loop
+threaded_detector.start_recog(sleep_time=0.03)
+
+# Let audio initialization happen before requesting input
+time.sleep(1)
+
+# Do a simple task separate from the detection - addition of numbers
+while not stop_program:
+    try:
+        num1 = int(raw_input("Enter the first number to add: "))
+        num2 = int(raw_input("Enter the second number to add: "))
+        print "Sum of number: {}".format(num1 + num2)
+    except ValueError:
+        print "You did not enter a number."
+
+threaded_detector.terminate()

--- a/examples/Python/snowboythreaded.py
+++ b/examples/Python/snowboythreaded.py
@@ -11,8 +11,8 @@ class ThreadedDetector(threading.Thread):
 
     def __init__(self, models, **kwargs):
         """
-        Initialize Detectors object. **kwargs is for any __init__ keyword arguments to be passed into HotWordDetector
-        __init__() method.
+        Initialize Detectors object. **kwargs is for any __init__ keyword
+        arguments to be passed into HotWordDetector __init__() method.
         """
         threading.Thread.__init__(self)
         self.models = models
@@ -31,7 +31,8 @@ class ThreadedDetector(threading.Thread):
 
     def run(self):
         """
-        Runs in separate thread - waits on command to either run detectors or terminate thread from commands queue
+        Runs in separate thread - waits on command to either run detectors
+        or terminate thread from commands queue
         """
         try:
             while True:
@@ -55,15 +56,16 @@ class ThreadedDetector(threading.Thread):
 
     def start_recog(self, **kwargs):
         """
-        Starts recognition in thread. Accepts kwargs to pass into the HotWordDetector.start() method, but
-        does not accept interrupt_callback, as that is already set up.
+        Starts recognition in thread. Accepts kwargs to pass into the
+        HotWordDetector.start() method, but does not accept interrupt_callback,
+        as that is already set up.
         """
         assert "interrupt_check" not in kwargs, \
             "Cannot set interrupt_check argument. To interrupt detectors, use Detectors.stop_recog() instead"
         self.run_kwargs = kwargs
         self.commands.put("Start")
 
-    def stop_recog(self):
+    def pause_recog(self):
         """
         Halts recognition in thread.
         """

--- a/examples/Python/snowboythreaded.py
+++ b/examples/Python/snowboythreaded.py
@@ -61,7 +61,7 @@ class ThreadedDetector(threading.Thread):
         as that is already set up.
         """
         assert "interrupt_check" not in kwargs, \
-            "Cannot set interrupt_check argument. To interrupt detectors, use Detectors.stop_recog() instead"
+            "Cannot set interrupt_check argument. To interrupt detectors, use Detectors.pause_recog() instead"
         self.run_kwargs = kwargs
         self.commands.put("Start")
 

--- a/examples/Python/snowboythreaded.py
+++ b/examples/Python/snowboythreaded.py
@@ -75,7 +75,7 @@ class ThreadedDetector(threading.Thread):
         """
         Terminates recognition thread - called when program terminates
         """
-        self.stop_recog()
+        self.pause_recog()
         self.commands.put("Terminate")
 
     def is_running(self):

--- a/examples/Python/snowboythreaded.py
+++ b/examples/Python/snowboythreaded.py
@@ -1,0 +1,92 @@
+import snowboydecoder
+import threading
+import Queue
+
+
+class ThreadedDetector(threading.Thread):
+    """
+    Wrapper class around detectors to run them in a separate thread
+    and provide methods to pause, resume, and modify detection
+    """
+
+    def __init__(self, models, **kwargs):
+        """
+        Initialize Detectors object. **kwargs is for any __init__ keyword arguments to be passed into HotWordDetector
+        __init__() method.
+        """
+        threading.Thread.__init__(self)
+        self.models = models
+        self.init_kwargs = kwargs
+        self.interrupted = True
+        self.commands = Queue.Queue()
+        self.vars_are_changed = True
+        self.detectors = None  # Initialize when thread is run in self.run()
+        self.run_kwargs = None  # Initialize when detectors start in self.start_recog()
+
+    def initialize_detectors(self):
+        """
+        Returns initialized Snowboy HotwordDetector objects
+        """
+        self.detectors = snowboydecoder.HotwordDetector(self.models, **self.init_kwargs)
+
+    def run(self):
+        """
+        Runs in separate thread - waits on command to either run detectors or terminate thread from commands queue
+        """
+        try:
+            while True:
+                command = self.commands.get(True)
+                if command == "Start":
+                    self.interrupted = False
+                    if self.vars_are_changed:
+                        # If there is an existing detector object, terminate it
+                        if self.detectors is not None:
+                            self.detectors.terminate()
+                        self.initialize_detectors()
+                        self.vars_are_changed = False
+                    # Start detectors - blocks until interrupted by self.interrupted variable
+                    self.detectors.start(interrupt_check=lambda: self.interrupted, **self.run_kwargs)
+                elif command == "Terminate":
+                    # Program ending - terminate thread
+                    break
+        finally:
+            if self.detectors is not None:
+                self.detectors.terminate()
+
+    def start_recog(self, **kwargs):
+        """
+        Starts recognition in thread. Accepts kwargs to pass into the HotWordDetector.start() method, but
+        does not accept interrupt_callback, as that is already set up.
+        """
+        assert "interrupt_check" not in kwargs, \
+            "Cannot set interrupt_check argument. To interrupt detectors, use Detectors.stop_recog() instead"
+        self.run_kwargs = kwargs
+        self.commands.put("Start")
+
+    def stop_recog(self):
+        """
+        Halts recognition in thread.
+        """
+        self.interrupted = True
+
+    def terminate(self):
+        """
+        Terminates recognition thread - called when program terminates
+        """
+        self.stop_recog()
+        self.commands.put("Terminate")
+
+    def is_running(self):
+        return not self.interrupted
+
+    def change_models(self, models):
+        if self.is_running():
+            print("Models will be changed after restarting detectors.")
+        self.models = models
+        self.vars_are_changed = True
+
+    def change_sensitivity(self, sensitivity):
+        if self.is_running():
+            print("Sensitivity will be changed after restarting detectors.")
+        self.init_kwargs['sensitivity'] = sensitivity
+        self.vars_are_changed = True

--- a/examples/Python/snowboythreaded.py
+++ b/examples/Python/snowboythreaded.py
@@ -82,11 +82,13 @@ class ThreadedDetector(threading.Thread):
     def change_models(self, models):
         if self.is_running():
             print("Models will be changed after restarting detectors.")
-        self.models = models
-        self.vars_are_changed = True
+        if self.models != models:
+            self.models = models
+            self.vars_are_changed = True
 
     def change_sensitivity(self, sensitivity):
         if self.is_running():
             print("Sensitivity will be changed after restarting detectors.")
-        self.init_kwargs['sensitivity'] = sensitivity
-        self.vars_are_changed = True
+        if self.init_kwargs['sensitivity'] != sensitivity:
+            self.init_kwargs['sensitivity'] = sensitivity
+            self.vars_are_changed = True


### PR DESCRIPTION
This provides a simple, straightforward interface to using Snowboy detectors in a separate thread to allow for a responsive UI. The wrapper class implements methods ThreadDetector.start() to start the thread, ThreadedDetector.start_recog() to begin hotword detection, ThreadedDetector.stop_recog() to halt detection, and ThreadedDetector.terminate() to terminate the detector and end the thread. 

To keep things consistent, ThreadedDetector.__init__() accepts keworded arguments to be relayed to HotwordDetector.__init__(), and ThreadedDetector.start_recog() accepts keworded arguments to be relayed to HotwordDetector.start(). With the latter, there is the exception of the interrupt_check argument, which is internally implemented by ThreadedDetector so that ThreadedDetector.stop_recog() can stop the detection. So, instead of implementing interrupt_check themselves, users of the ThreadedDetector class only need to call ThreadedDetector.stop().

Lastly, the ThreadedDetector class implements the method ThreadedDetector.is_running(), which returns a boolean for if the detectors are running or not, and the setters ThreadedDetector.change_models() and ThreadedDetector.change_sensitivity() to change the models and the sensitivity of the detectors, respectively. The re-initialization of the HotwordDetector objects is handled internally. 

