### PR TITLE
Rpi stretch py3 fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,3 +50,4 @@ Snowboy.pm
 
 /dist
 **/snowboy.egg-info
+/.idea

--- a/examples/Python3/snowboydecoder.py
+++ b/examples/Python3/snowboydecoder.py
@@ -2,7 +2,7 @@
 
 import collections
 import pyaudio
-import snowboydetect
+from . import snowboydetect
 import time
 import wave
 import os

--- a/setup.py
+++ b/setup.py
@@ -1,18 +1,21 @@
 import os
+import sys
 from setuptools import setup, find_packages
 from distutils.command.build import build
 from distutils.dir_util import copy_tree
 from subprocess import call
 
 
+py_dir = 'Python' if sys.version_info[0] < 3 else 'Python3'
+
 class SnowboyBuild(build):
 
     def run(self):
 
         cmd = ['make']
-
+        swig_dir = os.path.join('swig', py_dir)
         def compile():
-            call(cmd, cwd='swig/Python')
+            call(cmd, cwd=swig_dir)
 
         self.execute(compile, [], 'Compiling snowboy...')
 
@@ -20,7 +23,7 @@ class SnowboyBuild(build):
         self.mkpath(self.build_lib)
         snowboy_build_lib = os.path.join(self.build_lib, 'snowboy')
         self.mkpath(snowboy_build_lib)
-        target_file = 'swig/Python/_snowboydetect.so'
+        target_file = os.path.join(swig_dir, '_snowboydetect.so')
         if not self.dry_run:
             self.copy_file(target_file,
                            snowboy_build_lib)
@@ -42,8 +45,8 @@ setup(
     maintainer_email='snowboy@kitt.ai',
     license='Apache-2.0',
     url='https://snowboy.kitt.ai',
-    packages=find_packages('examples/Python/'),
-    package_dir={'snowboy': 'examples/Python/'},
+    packages=find_packages(os.path.join('examples', py_dir)),
+    package_dir={'snowboy': os.path.join('examples', py_dir)},
     py_modules=['snowboy.snowboydecoder', 'snowboy.snowboydetect'],
     package_data={'snowboy': ['resources/*']},
     zip_safe=False,


### PR DESCRIPTION
This fixes #271 for me, after these changes I can use `python setup.py build install` and it installs fine on latest Raspbian. However, it appears to me that your setup.py and general package layout needs some serious work (I'm not an expert though).