### PR TITLE
install dev dependencies before building for node 8.x [republish binary]

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -49,9 +49,9 @@ before_install:
 # put local node-pre-gyp on PATH
 - export PATH=./node_modules/.bin/:$PATH
 # put global node-gyp and nan on PATH
-- npm install nan node-gyp -g
+- npm install node-gyp -g
 # install aws-sdk so it is available for publishing
-- npm install aws-sdk
+- npm install aws-sdk nan typescript @types/node
 # figure out if we should publish or republish
 - PUBLISH_BINARY=false
 - REPUBLISH_BINARY=false


### PR DESCRIPTION
Managed to figure out what was going wrong with #333. We need to manually install dev dependencies for node 8.x before building from source.

I managed to get a green run for this config, so this PR should autogen and publish 8.x binaries: 
https://travis-ci.org/evancohen/snowboy/builds/322445532