### PR TITLE
Record from buffer after keyword detected

### DIFF
--- a/examples/Python3/demo4.py
+++ b/examples/Python3/demo4.py
@@ -6,8 +6,11 @@ import os
 
 """
 This demo file shows you how to use the new_message_callback to interact with
-the recorded audio after a keyword is spoken. It leverages the
-speech_recognition library in order to convert the recorded audio into text.
+the recorded audio after a keyword is spoken. It uses the speech recognition
+library in order to convert the recorded audio into text.
+
+Information on installing the speech recognition library can be found at:
+https://pypi.python.org/pypi/SpeechRecognition/
 """
 
 

--- a/examples/Python3/demo4.py
+++ b/examples/Python3/demo4.py
@@ -17,7 +17,7 @@ https://pypi.python.org/pypi/SpeechRecognition/
 interrupted = False
 
 
-def newMessageCallback(fname):
+def audioRecorderCallback(fname):
     print("converting audio to text")
     r = sr.Recognizer()
     with sr.AudioFile(fname) as source:
@@ -63,7 +63,10 @@ detector = snowboydecoder.HotwordDetector(model, sensitivity=0.38)
 print('Listening... Press Ctrl+C to exit')
 
 # main loop
-detector.start(detected_callback=detectedCallback, new_message_callback=newMessageCallback, interrupt_check=interrupt_callback, sleep_time=0.01)
+detector.start(detected_callback=detectedCallback,
+               audio_recorder_callback=audioRecorderCallback,
+               interrupt_check=interrupt_callback,
+               sleep_time=0.01)
 
 detector.terminate()
 

--- a/examples/Python3/demo4.py
+++ b/examples/Python3/demo4.py
@@ -1,0 +1,69 @@
+import snowboydecoder
+import sys
+import signal
+import speech_recognition as sr
+import os
+
+"""
+This demo file shows you how to use the new_message_callback to interact with
+the recorded audio after a keyword is spoken. It leverages the
+speech_recognition library in order to convert the recorded audio into text.
+"""
+
+
+interrupted = False
+
+
+def newMessageCallback(fname):
+    print("converting audio to text")
+    r = sr.Recognizer()
+    with sr.AudioFile(fname) as source:
+        audio = r.record(source)  # read the entire audio file
+    # recognize speech using Google Speech Recognition
+    try:
+        # for testing purposes, we're just using the default API key
+        # to use another API key, use `r.recognize_google(audio, key="GOOGLE_SPEECH_RECOGNITION_API_KEY")`
+        # instead of `r.recognize_google(audio)`
+        print(r.recognize_google(audio))
+    except sr.UnknownValueError:
+        print("Google Speech Recognition could not understand audio")
+    except sr.RequestError as e:
+        print("Could not request results from Google Speech Recognition service; {0}".format(e))
+
+    os.remove(fname)
+
+
+
+def detectedCallback():
+  print('recording audio...', end='', flush=True)
+
+def signal_handler(signal, frame):
+    global interrupted
+    interrupted = True
+
+
+def interrupt_callback():
+    global interrupted
+    return interrupted
+
+if len(sys.argv) == 1:
+    print("Error: need to specify model name")
+    print("Usage: python demo.py your.model")
+    sys.exit(-1)
+
+model = sys.argv[1]
+
+# capture SIGINT signal, e.g., Ctrl+C
+signal.signal(signal.SIGINT, signal_handler)
+
+detector = snowboydecoder.HotwordDetector(model, sensitivity=0.38)
+print('Listening... Press Ctrl+C to exit')
+
+# main loop
+detector.start(detected_callback=detectedCallback, new_message_callback=newMessageCallback, interrupt_check=interrupt_callback, sleep_time=0.01)
+
+detector.terminate()
+
+
+
+

--- a/examples/Python3/snowboydecoder.py
+++ b/examples/Python3/snowboydecoder.py
@@ -121,6 +121,15 @@ class HotwordDetector(object):
         :param interrupt_check: a function that returns True if the main loop
                                 needs to stop.
         :param float sleep_time: how much time in second every loop waits.
+        :param new_message_callback: if specified, this will be called after a
+                                     keyword has been spoken and after the
+                                     phrase immediately after the keyword has
+                                     been recorded. The function will be passed
+                                     the name of the file where the phrase was
+                                     recorded.
+        :param silance_count_threshold: indicates how long silence must be heard
+                                        to mark the end of a phrase that is
+                                        being recorded.
         :return: None
         """
         self._running = True

--- a/examples/Python3/snowboydecoder.py
+++ b/examples/Python3/snowboydecoder.py
@@ -105,7 +105,7 @@ class HotwordDetector(object):
     def start(self, detected_callback=play_audio_file,
               interrupt_check=lambda: False,
               sleep_time=0.03,
-              new_message_callback=None,
+              audio_recorder_callback=None,
               silence_count_threshold = 15):
         """
         Start the voice detector. For every `sleep_time` second it checks the
@@ -121,12 +121,12 @@ class HotwordDetector(object):
         :param interrupt_check: a function that returns True if the main loop
                                 needs to stop.
         :param float sleep_time: how much time in second every loop waits.
-        :param new_message_callback: if specified, this will be called after a
-                                     keyword has been spoken and after the
-                                     phrase immediately after the keyword has
-                                     been recorded. The function will be passed
-                                     the name of the file where the phrase was
-                                     recorded.
+        :param audio_recorder_callback: if specified, this will be called after
+                                        a keyword has been spoken and after the
+                                        phrase immediately after the keyword has
+                                        been recorded. The function will be
+                                        passed the name of the file where the
+                                        phrase was recorded.
         :param silance_count_threshold: indicates how long silence must be heard
                                         to mark the end of a phrase that is
                                         being recorded.
@@ -193,7 +193,7 @@ class HotwordDetector(object):
                     if callback is not None:
                         callback()
 
-                    if new_message_callback is not None:
+                    if audio_recorder_callback is not None:
                         state = "ACTIVE"
                     continue
 
@@ -201,7 +201,7 @@ class HotwordDetector(object):
                 if status == -2: #silence found
                     if silentCount > silence_count_threshold:
                         fname = self.saveMessage()
-                        new_message_callback(fname)
+                        audio_recorder_callback(fname)
                         state = "PASSIVE"
                         continue
                     else:


### PR DESCRIPTION
This code allows the HotwordDetector to automatically record a phrase that is spoken immediately after a keyword. It utilizes the internal buffer that is already being maintained by the HotwordDetector class. This is important because there is no overhead caused setting up a new audio stream.

The usage is as follows:
- If the user to specifies a newMessageCallback, any phrase spoken after a keyword will be saved to a WAV file. The name of this WAV file will be passed to the newMessageCallback and the user can use it as they wish. It should also be noted that the detectedCallback also still gets called as normal.
- If the user does not specify a newMessageCallback, the functionality of the library is completely unchanged from previous versions.
