### PR TITLE
Fix Python syntax errors and undefined names in examples

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -69,6 +69,8 @@ install:
 - node lib/node/index.js
 
 before_script:
+# python: check for syntax errors or undefined names
+- if [[ $NODE_VERSION == "9.0.0" ]]; then pip install flake8; flake8 . --select=E901,E999,F821,F822,F823; fi;
 # if publishing, do it
 - if [[ $REPUBLISH_BINARY == true ]]; then node-pre-gyp package unpublish; fi;
 - if [[ $PUBLISH_BINARY == true ]]; then node-pre-gyp package publish; fi;

--- a/examples/Python/demo4.py
+++ b/examples/Python/demo4.py
@@ -1,3 +1,5 @@
+from __future__ import print_function
+
 import snowboydecoder
 import sys
 import signal
@@ -18,7 +20,7 @@ interrupted = False
 
 
 def audioRecorderCallback(fname):
-    print "converting audio to text"
+    print("converting audio to text")
     r = sr.Recognizer()
     with sr.AudioFile(fname) as source:
         audio = r.record(source)  # read the entire audio file
@@ -29,9 +31,9 @@ def audioRecorderCallback(fname):
         # instead of `r.recognize_google(audio)`
         print(r.recognize_google(audio))
     except sr.UnknownValueError:
-        print "Google Speech Recognition could not understand audio"
+        print("Google Speech Recognition could not understand audio")
     except sr.RequestError as e:
-        print "Could not request results from Google Speech Recognition service; {0}".format(e)
+        print("Could not request results from Google Speech Recognition service; {0}".format(e))
 
     os.remove(fname)
 
@@ -51,8 +53,8 @@ def interrupt_callback():
     return interrupted
 
 if len(sys.argv) == 1:
-    print "Error: need to specify model name"
-    print "Usage: python demo.py your.model"
+    print("Error: need to specify model name")
+    print("Usage: python demo.py your.model")
     sys.exit(-1)
 
 model = sys.argv[1]
@@ -61,7 +63,7 @@ model = sys.argv[1]
 signal.signal(signal.SIGINT, signal_handler)
 
 detector = snowboydecoder.HotwordDetector(model, sensitivity=0.38)
-print "Listening... Press Ctrl+C to exit"
+print("Listening... Press Ctrl+C to exit")
 
 # main loop
 detector.start(detected_callback=detectedCallback,
@@ -70,7 +72,3 @@ detector.start(detected_callback=detectedCallback,
                sleep_time=0.01)
 
 detector.terminate()
-
-
-
-

--- a/examples/Python/demo_threaded.py
+++ b/examples/Python/demo_threaded.py
@@ -1,7 +1,14 @@
+from __future__ import print_function
+
 import snowboythreaded
 import sys
 import signal
 import time
+
+try:
+    raw_input          # Python 2
+except NameError:
+    raw_input = input  # Python 3
 
 stop_program = False
 
@@ -40,8 +47,8 @@ while not stop_program:
     try:
         num1 = int(raw_input("Enter the first number to add: "))
         num2 = int(raw_input("Enter the second number to add: "))
-        print "Sum of number: {}".format(num1 + num2)
+        print("Sum of number: {}".format(num1 + num2))
     except ValueError:
-        print "You did not enter a number."
+        print("You did not enter a number.")
 
 threaded_detector.terminate()

--- a/examples/Python3/demo4.py
+++ b/examples/Python3/demo4.py
@@ -1,3 +1,5 @@
+from __future__ import print_function
+
 import snowboydecoder
 import sys
 import signal
@@ -69,7 +71,3 @@ detector.start(detected_callback=detectedCallback,
                sleep_time=0.01)
 
 detector.terminate()
-
-
-
-

--- a/examples/REST_API/training_service.py
+++ b/examples/REST_API/training_service.py
@@ -1,5 +1,7 @@
 #! /usr/bin/evn python
 
+from __future__ import print_function
+
 import sys
 import base64
 import requests
@@ -25,7 +27,7 @@ if __name__ == "__main__":
     try:
         [_, wav1, wav2, wav3, out] = sys.argv
     except ValueError:
-        print "Usage: %s wave_file1 wave_file2 wave_file3 out_model_name" % sys.argv[0]
+        print("Usage: %s wave_file1 wave_file2 wave_file3 out_model_name" % sys.argv[0])
         sys.exit()
 
     data = {
@@ -46,7 +48,7 @@ if __name__ == "__main__":
     if response.ok:
         with open(out, "w") as outfile:
             outfile.write(response.content)
-        print "Saved model to '%s'." % out
+        print("Saved model to '%s'." % out)
     else:
-        print "Request failed."
-        print response.text
+        print("Request failed.")
+        print(response.text)


### PR DESCRIPTION
* Add [flake8](http://flake8.pycqa.org) testing of Python code to just one of the Travis CI runs.
* Fix the following issues to make all code _syntax_ compatible with both Python 2 and Python 3:
### Python 2
$ __python2 -m flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics__
```
./examples/Python3/demo4.py:41:34: E999 SyntaxError: invalid syntax
  print('recording audio...', end='', flush=True)
                                 ^
1     E999 SyntaxError: invalid syntax
1
```
### Python 3
$ __python3 -m flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics__
```
./examples/Python/demo_threaded.py:43:33: E999 SyntaxError: invalid syntax
        print "Sum of number: {}".format(num1 + num2)
                                ^
./examples/Python/demo4.py:21:36: E999 SyntaxError: invalid syntax
    print "converting audio to text"
                                   ^
./examples/REST_API/training_service.py:28:73: E999 SyntaxError: invalid syntax
        print "Usage: %s wave_file1 wave_file2 wave_file3 out_model_name" % sys.argv[0]
                                                                        ^
./examples/Python/demo_threaded.py:43:20: F821 undefined name 'raw_input'
        num1 = int(raw_input("Enter the first number to add: "))
                   ^
./examples/Python/demo_threaded.py:44:20: F821 undefined name 'raw_input'
        num2 = int(raw_input("Enter the second number to add: "))
                   ^
3     E999 SyntaxError: invalid syntax
2     F821 undefined name 'raw_input'
5
```
* The REST_API change is essential because it is not in either the Python or the Python3 directory.
* Perhaps the Python directory should be renamed to Python2.