### PR TITLE
fix type for ApplyFrontend

### DIFF
--- a/examples/iOS/Obj-C/SnowboyTest/ViewController.mm
+++ b/examples/iOS/Obj-C/SnowboyTest/ViewController.mm
@@ -31,7 +31,7 @@
                                                 std::string([[[NSBundle mainBundle]pathForResource:@"alexa" ofType:@"umdl"] UTF8String]));
     _snowboyDetect->SetSensitivity("0.5");
     _snowboyDetect->SetAudioGain(1.0);
-    _snowboyDetect->ApplyFrotnend(false);
+    _snowboyDetect->ApplyFrontend(false);
 }
 
 - (void) initMic {


### PR DESCRIPTION
There is a type in examples/iOS/Obj-C. After fixing this typo, the iOS example is successfully built in Xcode and tested in iOS simulator.