### PR TITLE
Update setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,6 +5,14 @@ from distutils.command.build import build
 from distutils.dir_util import copy_tree
 from subprocess import call
 
+try:
+    from wheel.bdist_wheel import bdist_wheel as _bdist_wheel
+    class bdist_wheel(_bdist_wheel):
+        def finalize_options(self):
+            _bdist_wheel.finalize_options(self)
+            self.root_is_pure = False
+except ImportError:
+    bdist_wheel = None
 
 py_dir = 'Python' if sys.version_info[0] < 3 else 'Python3'
 
@@ -56,6 +64,7 @@ setup(
         'PyAudio',
     ],
     cmdclass={
+        'bdist_wheel': bdist_wheel,
         'build': SnowboyBuild
     }
 )


### PR DESCRIPTION
[@hongquanand](https://github.com/hongquan) I was trying to build wheel packages for different platform but the current setup.py gives us`snowboy-1.3.0-py3-none-any.whl` instead of `snowboy-1.3.0-cp36-cp36m-linux_x86_64.whl` (on 64bit linux) or `snowboy-1.3.0-cp35-cp35m-linux_armv61.whl` (on armv6)
We're afraid that if we upload `snowboy-1.3.0-py3-none-any.whl` that is compiled using an x86_64 cpu, it will not be usable on an, for example, arm6 or arm7 cpu device (e.g. Raspberry Pi Zero, Pi 3B/3B+).

Reference taken from [Anthony Sottile from stackoverflow](https://stackoverflow.com/questions/45150304/how-to-force-a-python-wheel-to-be-platform-specific-when-building-it).