### PR TITLE
chore(node/package): update node-pre-gyp version

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   "gypfile": true,
   "license": "Apache-2.0",
   "dependencies": {
-    "node-pre-gyp": "^0.6.30"
+    "node-pre-gyp": "^0.10.3"
   },
   "devDependencies": {
     "@types/node": "^6.0.38",


### PR DESCRIPTION
Addresses #477 

`npm test` command isn't valid unfortunately, but I was able to do a basic test on this change with `npm link` and using the linked package verified that the `Detector` and `Models` still work as shown in the example.